### PR TITLE
Added styles, checkboxes and status indicators

### DIFF
--- a/app/assets/stylesheets/houston/dashboards/staging.scss
+++ b/app/assets/stylesheets/houston/dashboards/staging.scss
@@ -31,6 +31,24 @@
       &.staging-user {
         width: 26px;
       }
+
+      .pr-tag {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 4px;
+        line-height: 1;
+        margin-left: 8px;
+        &.test-needed {
+          background-color: #f7c6c7;
+        }
+        &.test-pass {
+          background-color: #009800;
+        }
+        &.test-hold {
+          background-color: #e11d21;
+        }
+      }
     }
   }
 }

--- a/app/assets/stylesheets/houston/dashboards/staging.scss
+++ b/app/assets/stylesheets/houston/dashboards/staging.scss
@@ -1,31 +1,65 @@
-.on-staging-pr {
-  padding: 10px;
-  a {
-    display: inline;
-    padding-left: 10px;
-    font-size: 1.33em;
-    font-weight: 200;
-  }
-}
-
-.staging-pr-project {
-  text-align: right;
-}
-
-.up-next-pr {
-  padding: 10px;
-  a {
-    display: inline;
-    padding-left: 10px;
-    font-size: 1.33em;
-    font-weight: 200;
-  }
-}
-
-.up-next-project {
-  text-align: right;
-}
-
-table {
+#on-staging {
+  table-layout: fixed;
   width: 100%;
+  tr.on-staging-pr {
+    padding: 10px;
+
+    a {
+      display: inline;
+      padding-left: 10px;
+      font-size: 1.33em;
+      font-weight: 200;
+    }
+
+    td {
+      padding: 1px 1em 1px 0;
+      white-space: nowrap;
+
+      &.staging-pr-project{
+        text-align: right;
+        width: 75px;
+      }
+
+      &.staging-pr-title{
+        width: 99%;
+      }
+
+      &.staging-user {
+        width: 26px;
+      }
+    }
+  }
+}
+
+#up-next {
+  table-layout: fixed;
+  width: 100%;
+  tr.up-next-pr {
+    padding: 10px;
+
+    a {
+      display: inline;
+      padding-left: 10px;
+      font-size: 1.33em;
+      font-weight: 200;
+    }
+
+    td {
+      padding: 1px 1em 1px 0;
+      white-space: nowrap;
+
+      &.up-next-project{
+        text-align: right;
+        width: 75px;
+      }
+
+      &.up-next-title{
+        width: 99%;
+      }
+
+      &.up-next-user {
+        width: 26px;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/houston/dashboards/staging.scss
+++ b/app/assets/stylesheets/houston/dashboards/staging.scss
@@ -39,9 +39,7 @@
         border-radius: 4px;
         line-height: 1;
         margin-left: 8px;
-        &.test-needed {
-          background-color: #f7c6c7;
-        }
+
         &.test-pass {
           background-color: #009800;
         }

--- a/app/assets/stylesheets/houston/dashboards/staging.scss
+++ b/app/assets/stylesheets/houston/dashboards/staging.scss
@@ -24,6 +24,10 @@
         width: 99%;
       }
 
+      &.checkboxes {
+        width: 40px;
+        text-align: right;
+      }
       &.staging-user {
         width: 26px;
       }
@@ -55,6 +59,11 @@
 
       &.up-next-title{
         width: 99%;
+      }
+
+      &.checkboxes {
+        width: 40px;
+        text-align: right;
       }
 
       &.up-next-user {

--- a/app/controllers/houston/dashboards/staging_controller.rb
+++ b/app/controllers/houston/dashboards/staging_controller.rb
@@ -41,11 +41,16 @@ private
   end
 
   def test_needed_pull_requests(project)
-    Houston.github.list_issues(
+    pull_requests = Houston.github.list_issues(
       "#{github_org}/#{project.slug}",
       labels: "test-needed",
       filter: "all")
         .select(&:pull_request)
+
+    pull_requests.reject do |pull_request|
+      labels = pull_request.labels.map(&:name)
+      labels.include?("on-staging")
+    end
   end
 
   def github_org

--- a/app/controllers/houston/dashboards/staging_controller.rb
+++ b/app/controllers/houston/dashboards/staging_controller.rb
@@ -1,59 +1,14 @@
 class Houston::Dashboards::StagingController < ApplicationController
   layout "houston/dashboards/dashboard"
-  STAGING_PROJECTS = %w(members unite ledger bsb members-dav)
+
   def index
-    @on_staging = currently_on_staging
-    @up_next = up_next
+    @on_staging = Houston.github.org_issues(Houston.config.github[:organization], filter: "all", labels: "on-staging")
+    @up_next = Houston.github.org_issues(Houston.config.github[:organization], filter: "all", labels: "test-needed")
 
     @title = "Staging"
+    @title << " (#{@on_staging.count})" if @on_staging.count > 0
 
     render partial: "houston/dashboards/staging/staging" if request.xhr?
   end
 
-private
-
-  def currently_on_staging
-    on_staging = Hash.new
-    STAGING_PROJECTS.each do |slug|
-      project = Project.find_by_slug slug
-      pull_request = on_staging_pull_requests(project)
-      on_staging[slug] = {pull_request: pull_request, project: project} unless pull_request.nil?
-    end
-    on_staging
-  end
-
-  def up_next
-    up_next = Hash.new
-    STAGING_PROJECTS.each do |slug|
-      project = Project.find_by_slug slug
-      pull_requests = test_needed_pull_requests(project)
-      up_next[slug] = {pull_requests: pull_requests, project: project} unless pull_requests.empty?
-    end
-    up_next
-  end
-
-  def on_staging_pull_requests(project)
-    Houston.github.list_issues(
-      "#{github_org}/#{project.slug}",
-      labels: "on-staging",
-      filter: "all")
-        .select(&:pull_request).first
-  end
-
-  def test_needed_pull_requests(project)
-    pull_requests = Houston.github.list_issues(
-      "#{github_org}/#{project.slug}",
-      labels: "test-needed",
-      filter: "all")
-        .select(&:pull_request)
-
-    pull_requests.reject do |pull_request|
-      labels = pull_request.labels.map(&:name)
-      labels.include?("on-staging")
-    end
-  end
-
-  def github_org
-    Houston.config.github[:organization]
-  end
 end

--- a/app/controllers/houston/dashboards/staging_controller.rb
+++ b/app/controllers/houston/dashboards/staging_controller.rb
@@ -2,8 +2,8 @@ class Houston::Dashboards::StagingController < ApplicationController
   layout "houston/dashboards/dashboard"
 
   def index
-    @on_staging = Houston.github.org_issues(Houston.config.github[:organization], filter: "all", labels: "on-staging")
-    @up_next = Houston.github.org_issues(Houston.config.github[:organization], filter: "all", labels: "test-needed")
+    @on_staging = Github::PullRequest.labeled "on-staging"
+    @up_next = Github::PullRequest.labeled "test-needed"
 
     @title = "Staging"
     @title << " (#{@on_staging.count})" if @on_staging.count > 0

--- a/app/controllers/houston/dashboards/staging_controller.rb
+++ b/app/controllers/houston/dashboards/staging_controller.rb
@@ -1,6 +1,6 @@
 class Houston::Dashboards::StagingController < ApplicationController
   layout "houston/dashboards/dashboard"
-  STAGING_PROJECTS = %w(members unite ledger bsb)
+  STAGING_PROJECTS = %w(members unite ledger bsb members-dav)
   def index
     @on_staging = currently_on_staging
     @up_next = up_next

--- a/app/helpers/houston/dashboards/staging_helper.rb
+++ b/app/helpers/houston/dashboards/staging_helper.rb
@@ -25,5 +25,10 @@ module Houston::Dashboards
       end
       label_out.html_safe
     end
+
+    def pr_project_color(pull_request)
+      project = Project.find_by(slug: pull_request.repository.name)
+      project.nil? ? '' : project.color
+    end
   end
 end

--- a/app/helpers/houston/dashboards/staging_helper.rb
+++ b/app/helpers/houston/dashboards/staging_helper.rb
@@ -18,7 +18,7 @@ module Houston::Dashboards
     end
 
     def staging_status(pull_request)
-      labels = pull_request.labels.map(&:name).select { |name| ['test-pass', 'test-hold'].include?(name)}
+      labels = pull_request.labels.select { |name| ['test-pass', 'test-hold'].include?(name)}
       label_out = ""
       labels.each do |label|
         label_out << "<span class=\"pr-tag #{label}\">&nbsp;</span>"
@@ -26,9 +26,5 @@ module Houston::Dashboards
       label_out.html_safe
     end
 
-    def pr_project_color(pull_request)
-      project = Project.find_by(slug: pull_request.repository.name)
-      project.nil? ? '' : project.color
-    end
   end
 end

--- a/app/helpers/houston/dashboards/staging_helper.rb
+++ b/app/helpers/houston/dashboards/staging_helper.rb
@@ -18,7 +18,7 @@ module Houston::Dashboards
     end
 
     def staging_status(pull_request)
-      labels = pull_request.labels.map(&:name).select { |name| ['test-needed', 'test-pass', 'test-hold'].include?(name)}
+      labels = pull_request.labels.map(&:name).select { |name| ['test-pass', 'test-hold'].include?(name)}
       label_out = ""
       labels.each do |label|
         label_out << "<span class=\"pr-tag #{label}\">&nbsp;</span>"

--- a/app/helpers/houston/dashboards/staging_helper.rb
+++ b/app/helpers/houston/dashboards/staging_helper.rb
@@ -16,5 +16,14 @@ module Houston::Dashboards
       not_completed = pull_request.body.scan("[ ]").count
       completed + not_completed
     end
+
+    def staging_status(pull_request)
+      labels = pull_request.labels.map(&:name).select { |name| ['test-needed', 'test-pass', 'test-hold'].include?(name)}
+      label_out = ""
+      labels.each do |label|
+        label_out << "<span class=\"pr-tag #{label}\">&nbsp;</span>"
+      end
+      label_out
+    end
   end
 end

--- a/app/helpers/houston/dashboards/staging_helper.rb
+++ b/app/helpers/houston/dashboards/staging_helper.rb
@@ -1,5 +1,12 @@
 module Houston::Dashboards
   module StagingHelper
+
+    def checkboxes(pull_request)
+      checked = completed_checkboxes(pull_request)
+      total = total_checkboxes(pull_request)
+      "<span class='label'>#{checked}/#{total}</span>" unless total < 1
+    end
+
     def completed_checkboxes(pull_request)
       pull_request.body.scan("[x]").count
     end

--- a/app/helpers/houston/dashboards/staging_helper.rb
+++ b/app/helpers/houston/dashboards/staging_helper.rb
@@ -1,0 +1,13 @@
+module Houston::Dashboards
+  module StagingHelper
+    def completed_checkboxes(pull_request)
+      pull_request.body.scan("[x]").count
+    end
+
+    def total_checkboxes(pull_request)
+      completed = pull_request.body.scan("[x]").count
+      not_completed = pull_request.body.scan("[ ]").count
+      completed + not_completed
+    end
+  end
+end

--- a/app/helpers/houston/dashboards/staging_helper.rb
+++ b/app/helpers/houston/dashboards/staging_helper.rb
@@ -4,7 +4,7 @@ module Houston::Dashboards
     def checkboxes(pull_request)
       checked = completed_checkboxes(pull_request)
       total = total_checkboxes(pull_request)
-      "<span class='label'>#{checked}/#{total}</span>" unless total < 1
+      "<span class='label'>#{checked}/#{total}</span>".html_safe unless total < 1
     end
 
     def completed_checkboxes(pull_request)
@@ -23,7 +23,7 @@ module Houston::Dashboards
       labels.each do |label|
         label_out << "<span class=\"pr-tag #{label}\">&nbsp;</span>"
       end
-      label_out
+      label_out.html_safe
     end
   end
 end

--- a/app/views/houston/dashboards/staging/_on_staging.html.erb
+++ b/app/views/houston/dashboards/staging/_on_staging.html.erb
@@ -8,6 +8,9 @@
       <td class="staging-pr-title">
         <%= link_to truncate(info[:pull_request].title, length: 100), info[:pull_request].html_url, target: "_blank" %>
       </td>
+      <td class="checkboxes">
+        <span class="label"> <%= completed_checkboxes(info[:pull_request]) %>/<%= total_checkboxes(info[:pull_request]) %></span>
+      </td>
       <td class="staging-user">
         <img class="avatar" src="<%= info[:pull_request].user.avatar_url %>;s=52" width="26" height="26" alt="<%= info[:pull_request].user.login %>">
       </td>

--- a/app/views/houston/dashboards/staging/_on_staging.html.erb
+++ b/app/views/houston/dashboards/staging/_on_staging.html.erb
@@ -7,6 +7,7 @@
       </td>
       <td class="staging-pr-title">
         <%= link_to truncate(info[:pull_request].title, length: 100), info[:pull_request].html_url, target: "_blank" %>
+        <%= raw staging_status(info[:pull_request]) %>
       </td>
       <td class="checkboxes">
         <%= raw(checkboxes(info[:pull_request])) %>

--- a/app/views/houston/dashboards/staging/_on_staging.html.erb
+++ b/app/views/houston/dashboards/staging/_on_staging.html.erb
@@ -7,10 +7,10 @@
       </td>
       <td class="staging-pr-title">
         <%= link_to truncate(info[:pull_request].title, length: 100), info[:pull_request].html_url, target: "_blank" %>
-        <%= raw staging_status(info[:pull_request]) %>
+        <%= staging_status(info[:pull_request]) %>
       </td>
       <td class="checkboxes">
-        <%= raw(checkboxes(info[:pull_request])) %>
+        <%= checkboxes(info[:pull_request]) %>
       </td>
       <td class="staging-user">
         <img class="avatar" src="<%= info[:pull_request].user.avatar_url %>;s=52" width="26" height="26" alt="<%= info[:pull_request].user.login %>">

--- a/app/views/houston/dashboards/staging/_on_staging.html.erb
+++ b/app/views/houston/dashboards/staging/_on_staging.html.erb
@@ -1,20 +1,19 @@
-  <% @on_staging.each do |pull_request| %>
-    <tr class="on-staging-pr">
-      <td class="staging-pr-project">
-        <span class="label <%= pr_project_color(pull_request)%>">
-          <%= pull_request.repository.name %>
-        </span>
-      </td>
-      <td class="staging-pr-title">
-        <%= link_to truncate(pull_request.title, length: 100), pull_request.html_url, target: "_blank" %>
-        <%= staging_status(pull_request) %>
-      </td>
-      <td class="checkboxes">
-        <%= checkboxes(pull_request) %>
-      </td>
-      <td class="staging-user">
-        <img class="avatar" src="<%= pull_request.user.avatar_url %>;s=52" width="26" height="26" alt="<%= pull_request.user.login %>">
-      </td>
-    </tr>
-
-  <% end %>
+<% @on_staging.each do |pull_request| %>
+  <tr class="on-staging-pr">
+    <td class="staging-pr-project">
+      <span class="label <%= pull_request.project.color %>">
+        <%= pull_request.repo %>
+      </span>
+    </td>
+    <td class="staging-pr-title">
+      <%= link_to truncate(pull_request.title, length: 100), pull_request.url, target: "_blank" %>
+      <%= staging_status(pull_request) %>
+    </td>
+    <td class="checkboxes">
+      <%= checkboxes(pull_request) %>
+    </td>
+    <td class="staging-user">
+      <%= avatar_for(pull_request.user) %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/houston/dashboards/staging/_on_staging.html.erb
+++ b/app/views/houston/dashboards/staging/_on_staging.html.erb
@@ -9,7 +9,7 @@
         <%= link_to truncate(info[:pull_request].title, length: 100), info[:pull_request].html_url, target: "_blank" %>
       </td>
       <td class="checkboxes">
-        <span class="label"> <%= completed_checkboxes(info[:pull_request]) %>/<%= total_checkboxes(info[:pull_request]) %></span>
+        <%= raw(checkboxes(info[:pull_request])) %>
       </td>
       <td class="staging-user">
         <img class="avatar" src="<%= info[:pull_request].user.avatar_url %>;s=52" width="26" height="26" alt="<%= info[:pull_request].user.login %>">

--- a/app/views/houston/dashboards/staging/_on_staging.html.erb
+++ b/app/views/houston/dashboards/staging/_on_staging.html.erb
@@ -1,19 +1,19 @@
-  <% @on_staging.each do |slug, info| %>
+  <% @on_staging.each do |pull_request| %>
     <tr class="on-staging-pr">
       <td class="staging-pr-project">
-        <span class="label <%= info[:project].color %>">
-          <%= info[:project].slug %>
+        <span class="label <%= pr_project_color(pull_request)%>">
+          <%= pull_request.repository.name %>
         </span>
       </td>
       <td class="staging-pr-title">
-        <%= link_to truncate(info[:pull_request].title, length: 100), info[:pull_request].html_url, target: "_blank" %>
-        <%= staging_status(info[:pull_request]) %>
+        <%= link_to truncate(pull_request.title, length: 100), pull_request.html_url, target: "_blank" %>
+        <%= staging_status(pull_request) %>
       </td>
       <td class="checkboxes">
-        <%= checkboxes(info[:pull_request]) %>
+        <%= checkboxes(pull_request) %>
       </td>
       <td class="staging-user">
-        <img class="avatar" src="<%= info[:pull_request].user.avatar_url %>;s=52" width="26" height="26" alt="<%= info[:pull_request].user.login %>">
+        <img class="avatar" src="<%= pull_request.user.avatar_url %>;s=52" width="26" height="26" alt="<%= pull_request.user.login %>">
       </td>
     </tr>
 

--- a/app/views/houston/dashboards/staging/_up_next.html.erb
+++ b/app/views/houston/dashboards/staging/_up_next.html.erb
@@ -10,6 +10,9 @@
         <td class="up-next-title">
           <%= link_to truncate(pull_request.title, length: 100), pull_request.html_url, target: "_blank" %>
         </td>
+        <td class="checkboxes">
+          <span class="label"> <%= completed_checkboxes(pull_request) %>/<%= total_checkboxes(pull_request) %></span>
+        </td>
         <td class="up-next-user">
           <img class="avatar" src="<%= pull_request.user.avatar_url %>;s=52" width="26" height="26" alt="<%= pull_request.user.login %>">
         </td>

--- a/app/views/houston/dashboards/staging/_up_next.html.erb
+++ b/app/views/houston/dashboards/staging/_up_next.html.erb
@@ -11,7 +11,7 @@
           <%= link_to truncate(pull_request.title, length: 100), pull_request.html_url, target: "_blank" %>
         </td>
         <td class="checkboxes">
-          <span class="label"> <%= completed_checkboxes(pull_request) %>/<%= total_checkboxes(pull_request) %></span>
+          <%= raw(checkboxes(pull_request)) %>
         </td>
         <td class="up-next-user">
           <img class="avatar" src="<%= pull_request.user.avatar_url %>;s=52" width="26" height="26" alt="<%= pull_request.user.login %>">

--- a/app/views/houston/dashboards/staging/_up_next.html.erb
+++ b/app/views/houston/dashboards/staging/_up_next.html.erb
@@ -1,22 +1,20 @@
-<% @up_next.each do |slug, project_data| %>
+<% @up_next.each do |pull_request| %>
 
-    <% project_data[:pull_requests].each do |pull_request| %>
-      <tr class="up-next-pr">
-        <td class="up-next-project">
-          <span class="label <%= project_data[:project].color %>">
-            <%= project_data[:project].slug %>
-          </span>
-        </td>
-        <td class="up-next-title">
-          <%= link_to truncate(pull_request.title, length: 100), pull_request.html_url, target: "_blank" %>
-        </td>
-        <td class="checkboxes">
-          <%= checkboxes(pull_request) %>
-        </td>
-        <td class="up-next-user">
-          <img class="avatar" src="<%= pull_request.user.avatar_url %>;s=52" width="26" height="26" alt="<%= pull_request.user.login %>">
-        </td>
-      </tr>
-    <% end %>
+    <tr class="up-next-pr">
+      <td class="up-next-project">
+        <span class="label <%= pr_project_color(pull_request) %>">
+          <%= pull_request.repository.name %>
+        </span>
+      </td>
+      <td class="up-next-title">
+        <%= link_to truncate(pull_request.title, length: 100), pull_request.html_url, target: "_blank" %>
+      </td>
+      <td class="checkboxes">
+        <%= checkboxes(pull_request) %>
+      </td>
+      <td class="up-next-user">
+        <img class="avatar" src="<%= pull_request.user.avatar_url %>;s=52" width="26" height="26" alt="<%= pull_request.user.login %>">
+      </td>
+    </tr>
 
 <% end %>

--- a/app/views/houston/dashboards/staging/_up_next.html.erb
+++ b/app/views/houston/dashboards/staging/_up_next.html.erb
@@ -11,7 +11,7 @@
           <%= link_to truncate(pull_request.title, length: 100), pull_request.html_url, target: "_blank" %>
         </td>
         <td class="checkboxes">
-          <%= raw(checkboxes(pull_request)) %>
+          <%= checkboxes(pull_request) %>
         </td>
         <td class="up-next-user">
           <img class="avatar" src="<%= pull_request.user.avatar_url %>;s=52" width="26" height="26" alt="<%= pull_request.user.login %>">

--- a/app/views/houston/dashboards/staging/_up_next.html.erb
+++ b/app/views/houston/dashboards/staging/_up_next.html.erb
@@ -7,10 +7,10 @@
             <%= project_data[:project].slug %>
           </span>
         </td>
-        <td class="staging-pr-title">
+        <td class="up-next-title">
           <%= link_to truncate(pull_request.title, length: 100), pull_request.html_url, target: "_blank" %>
         </td>
-        <td class="staging-user">
+        <td class="up-next-user">
           <img class="avatar" src="<%= pull_request.user.avatar_url %>;s=52" width="26" height="26" alt="<%= pull_request.user.login %>">
         </td>
       </tr>

--- a/app/views/houston/dashboards/staging/_up_next.html.erb
+++ b/app/views/houston/dashboards/staging/_up_next.html.erb
@@ -1,20 +1,18 @@
 <% @up_next.each do |pull_request| %>
-
     <tr class="up-next-pr">
       <td class="up-next-project">
-        <span class="label <%= pr_project_color(pull_request) %>">
-          <%= pull_request.repository.name %>
+        <span class="label <%= pull_request.project.color %>">
+          <%= pull_request.repo %>
         </span>
       </td>
       <td class="up-next-title">
-        <%= link_to truncate(pull_request.title, length: 100), pull_request.html_url, target: "_blank" %>
+        <%= link_to truncate(pull_request.title, length: 100), pull_request.url, target: "_blank" %>
       </td>
       <td class="checkboxes">
         <%= checkboxes(pull_request) %>
       </td>
       <td class="up-next-user">
-        <img class="avatar" src="<%= pull_request.user.avatar_url %>;s=52" width="26" height="26" alt="<%= pull_request.user.login %>">
+        <%= avatar_for(pull_request.user) %>
       </td>
     </tr>
-
 <% end %>


### PR DESCRIPTION
This should fix the styling issues for the PR tables. 

I also added a label that shows PR checkbox status
<img width="1054" alt="checkboxes" src="https://cloud.githubusercontent.com/assets/3615754/10960139/db4c7048-8346-11e5-8954-99e1d2e9d002.png">

We added testing status indicators for pull requests on staging
<img width="1108" alt="indicators" src="https://cloud.githubusercontent.com/assets/3615754/10971538/6b72ffe0-839a-11e5-9de1-85443582e38b.png">
