### PR TITLE
Filtered up next pull request using new "without_labels" method

### DIFF
--- a/app/controllers/houston/dashboards/staging_controller.rb
+++ b/app/controllers/houston/dashboards/staging_controller.rb
@@ -3,9 +3,7 @@ class Houston::Dashboards::StagingController < ApplicationController
 
   def index
     @on_staging = Github::PullRequest.labeled "on-staging"
-    @up_next = Github::PullRequest.labeled("test-needed").reject do |pr|
-      pr.labels.include? "on-staging" || "wip"
-    end
+    @up_next = Github::PullRequest.labeled("test-needed").without_labels("on-staging", "wip", "experimental")
 
     @title = "Staging"
     @title << " (#{@on_staging.count})" if @on_staging.count > 0


### PR DESCRIPTION
Depends on `houston-core` [PR #131](https://github.com/houston/houston-core/pull/131)
